### PR TITLE
Fixing match patterns

### DIFF
--- a/extension/source/page.js
+++ b/extension/source/page.js
@@ -125,15 +125,15 @@ class Page {
 	 * @param {Document} doc the document that should be checked
 	 */
 	check (doc) {
-		if (doc.body.textContent.search(/F.+r\sdie\sDauer\svon\sZAT\s.+\ssind\sdie\sSeiten\svon\sOS\s2\.0\sgesperrt!/) != -1) {
+		if (doc.body.textContent.search(/F.r\sdie\sDauer\svon\sZAT\s.+\ssind\sdie\sSeiten\svon\sOS\s2\.0\sgesperrt!/) != -1) {
 			throw new Warning('Auswertung läuft');
 		}
-		else if (doc.body.textContent.search(/(Willkommen im Managerb.+ro von )*Demo[T|t]eam/) != -1 ||
-			doc.body.textContent.search(/Diese Seite ist ohne Team nicht verf.+gbar!/) != -1 ||
+		else if (doc.body.textContent.search(/Willkommen im Managerb.ro von Demo[Tt]eam/) != -1 ||
+			doc.body.textContent.search(/Diese Seite ist ohne Team nicht verf.gbar!/) != -1 ||
 			doc.body.textContent.search(/.*Als Gast gesperrt.*/) != -1) {
 			throw new Warning('Anmeldung erforderlich');
 		}
-		else if (doc.body.textContent.search(/Diese Funktion ist erst ZAT 1 wieder verf.+gbar/) != -1) {
+		else if (doc.body.textContent.search(/Diese Funktion ist erst ZAT 1 wieder verf.gbar/) != -1) {
 			throw new Warning('Saisonwechsel läuft');
 		}
 	}

--- a/extension/source/pages/accountstatement.js
+++ b/extension/source/pages/accountstatement.js
@@ -28,14 +28,14 @@ Page.AccountStatement = class extends Page {
 
 		let matches = /Kontoauszug - Kontostand : ([\d.]+) Euro/gm.exec(doc.querySelector('b > font').textContent);	
 		if (matches) {	
-			data.team.accountBalance = +matches[1].replace(/\./g, '');
+			data.team.accountBalance = +matches[1].replaceAll('.', '');
 		}
 
 		HtmlUtil.getTableRowsByHeader(doc, ...Page.AccountStatement.HEADERS).forEach(row => {
 			
 			matches = /Abrechnung ZAT (\d+)/gm.exec(row.cells['Buchungstext'].textContent);
 			if (matches) {
-				data.team.getMatchDay(season, +matches[1]).accountBalance = +row.cells['Kontostand nach Buchung'].textContent.replace(/\./g, '');
+				data.team.getMatchDay(season, +matches[1]).accountBalance = +row.cells['Kontostand nach Buchung'].textContent.replaceAll('.', '');
 			}
 		});
 

--- a/extension/source/pages/contractextension.js
+++ b/extension/source/pages/contractextension.js
@@ -20,10 +20,10 @@ Page.ContractExtension = class extends Page {
 			let id = HtmlUtil.extractIdFromHref(row.cells['Name'].firstChild.href);
 			let player = data.team.getSquadPlayer(id); 
 			
-			player.followUpSalary['24'] = +row.cells[8].textContent.replace(/\./g, '');
-			player.followUpSalary['36'] = +row.cells[10].textContent.replace(/\./g, '');
-			player.followUpSalary['48'] = +row.cells[12].textContent.replace(/\./g, '');
-			player.followUpSalary['60'] = +row.cells[14].textContent.replace(/\./g, '');
+			player.followUpSalary['24'] = +row.cells[8].textContent.replaceAll('.', '');
+			player.followUpSalary['36'] = +row.cells[10].textContent.replaceAll('.', '');
+			player.followUpSalary['48'] = +row.cells[12].textContent.replaceAll('.', '');
+			player.followUpSalary['60'] = +row.cells[14].textContent.replaceAll('.', '');
 
 		});
 

--- a/extension/source/pages/loanview.js
+++ b/extension/source/pages/loanview.js
@@ -28,7 +28,7 @@ Page.LoanView = class extends Page {
 				else if (nameCell.firstChild.href) {
 					let id = HtmlUtil.extractIdFromHref(nameCell.firstChild.href);
 					let player = data.team.getSquadPlayer(id);
-					player.loan.fee = +row.cells['Leihgebühr'].textContent.replace(/\./g, "");
+					player.loan.fee = +row.cells['Leihgebühr'].textContent.replaceAll('.', '');
 					if (expense) player.loan.fee *= -1;
 					player.pos = nameCell.className;
 				}

--- a/extension/source/pages/main.js
+++ b/extension/source/pages/main.js
@@ -18,7 +18,7 @@ Page.Main = class extends Page {
 		super.check(doc);
 
 		let teamChangeLink = doc.querySelector('a[href="?changetosecond=true"]');
-		let matches = /Willkommen im Managerbüro von (.+)/gm.exec(teamChangeLink.parentElement.childNodes[0].textContent);
+		let matches = /Willkommen im Managerb.ro von (.+)/gm.exec(teamChangeLink.parentElement.childNodes[0].textContent);
 
 		let page = this;
 		let superProcess = super.process;
@@ -72,18 +72,18 @@ Page.Main = class extends Page {
 		
 		let titleContainer = doc.querySelector('a[href="?changetosecond=true"]').parentElement;
 
-		matches = /Willkommen im Managerbüro von (.+)/gm.exec(titleContainer.childNodes[0].textContent);
+		matches = /Willkommen im Managerb.ro von (.+)/gm.exec(titleContainer.childNodes[0].textContent);
 			
 		data.team.name = matches[1];
 
-		matches = /(\d)\. Liga (.+)/gm.exec(titleContainer.childNodes[2].textContent);
+		matches = /(\d)\. Liga ?[A-D]? (.+)/gm.exec(titleContainer.childNodes[2].textContent);
 
 		data.team.league.level = +matches[1];
 		data.team.league.countryName = matches[2];
 		
 		let accountBalanceElement = doc.querySelector('a[href="ka.php"]');
 		if (accountBalanceElement) {
-			data.team.accountBalance = +accountBalanceElement.textContent.replace(/\./g, '').replace(' Euro', '');
+			data.team.accountBalance = +accountBalanceElement.textContent.replaceAll('.', '').replace(' Euro', '');
 		}
 
 	}

--- a/extension/source/pages/showteam.contracts.js
+++ b/extension/source/pages/showteam.contracts.js
@@ -22,8 +22,8 @@ Page.ShowteamContracts = class extends Page.Showteam {
 			
 			player.birthday = +row.cells['Geb.Tag'].textContent;
 			player.contractTerm = +row.cells['Vertrag'].textContent;
-			player.salary = +row.cells['Monatsgehalt'].textContent.replace(/\./g, '');
-			player.marketValue = +row.cells['Spielerwert'].textContent.replace(/\./g, '');
+			player.salary = +row.cells['Monatsgehalt'].textContent.replaceAll('.', '');
+			player.marketValue = +row.cells['Spielerwert'].textContent.replaceAll('.', '');
 
 		});
 

--- a/extension/source/pages/showteam.info.js
+++ b/extension/source/pages/showteam.info.js
@@ -27,10 +27,10 @@ Page.ShowteamInfo = class extends Page {
 		}
 
 		data.team.stadium = Object.assign(new Stadium(), data.team.stadium);
-		data.team.stadium.coveredSeats = +table.rows[2].cells[3].textContent.replace(/\./g, '');
-		data.team.stadium.seats = +table.rows[2].cells[1].textContent.replace(/\./g, '') - data.team.stadium.coveredSeats;
-		data.team.stadium.coveredPlaces = +table.rows[3].cells[3].textContent.replace(/\./g, '');
-		data.team.stadium.places = +table.rows[3].cells[1].textContent.replace(/\./g, '') - data.team.stadium.coveredPlaces;
+		data.team.stadium.coveredSeats = +table.rows[2].cells[3].textContent.replaceAll('.', '');
+		data.team.stadium.seats = +table.rows[2].cells[1].textContent.replaceAll('.', '') - data.team.stadium.coveredSeats;
+		data.team.stadium.coveredPlaces = +table.rows[3].cells[3].textContent.replaceAll('.', '');
+		data.team.stadium.places = +table.rows[3].cells[1].textContent.replaceAll('.', '') - data.team.stadium.coveredPlaces;
 		data.team.stadium.pitchHeating = (table.rows[4].cells[3].textContent == 'Ja');
 
 		let expansionElement = doc.querySelector('td[class="TOR"] > b');
@@ -72,35 +72,35 @@ Page.ShowteamInfo = class extends Page {
 		if (expansionTable) {
 			Array.from(expansionTable.rows).filter(row => row.textContent.trim().length > 0).slice(1).forEach(row => {
 				let text = row.textContent; 					
-				let value = +text.split(" ")[0].replace(/\./g, '');
+				let value = +text.split(" ")[0].replaceAll('.', '');
 				if (text.search(/Eine Rasenheizung wird gebaut/) != -1) {
 					stadium.pitchHeating = true;
 				}
-				else if (text.search(/[\d.]+ .+berdachte Stehpl.+tze werden zu Sitzpl.+tzen umgebaut/) != -1) {
+				else if (text.search(/[\d.]+ .berdachte Stehpl.tze werden zu Sitzpl.tzen umgebaut/) != -1) {
 					stadium.coveredPlaces -= value;
 					stadium.coveredSeats += value;
 				}
-				else if (text.search(/[\d.]+ Stehpl.+tze werden zu Sitzpl.+tzen umgebaut/) != -1) {
+				else if (text.search(/[\d.]+ Stehpl.tze werden zu Sitzpl.tzen umgebaut/) != -1) {
 					stadium.places -= value;
 					stadium.seats += value;
 				}
-				else if (text.search(/[\d.]+ .+berdachte Sitzpl.+tze werden gebaut/) != -1) {
+				else if (text.search(/[\d.]+ .berdachte Sitzpl.tze werden gebaut/) != -1) {
 					stadium.coveredSeats += value;
 				}
-				else if (text.search(/[\d.]+ Sitzpl.+tze werden gebaut/) != -1) {
+				else if (text.search(/[\d.]+ Sitzpl.tze werden gebaut/) != -1) {
 					stadium.seats += value;
 				}
-				else if (text.search(/[\d.]+ .+berdachte Stehpl.+tze werden gebaut/) != -1) {
+				else if (text.search(/[\d.]+ .berdachte Stehpl.tze werden gebaut/) != -1) {
 					stadium.coveredPlaces += value;
 				}
-				else if (text.search(/[\d.]+ Stehpl.+tze werden gebaut/) != -1) {
+				else if (text.search(/[\d.]+ Stehpl.tze werden gebaut/) != -1) {
 					stadium.places += value;
 				}
-				else if (text.search(/[\d.]+ Sitzpl.+tze werden .+berdacht/) != -1) {
+				else if (text.search(/[\d.]+ Sitzpl.tze werden .berdacht/) != -1) {
 					stadium.coveredSeats += value;
 					stadium.seats -= value;
 				}
-				else if (text.search(/[\d.]+ Stehpl.+tze werden .+berdacht/) != -1) {
+				else if (text.search(/[\d.]+ Stehpl.tze werden .berdacht/) != -1) {
 					stadium.coveredPlaces += value;
 					stadium.places -= value;
 				}

--- a/extension/source/pages/trainer.js
+++ b/extension/source/pages/trainer.js
@@ -22,7 +22,7 @@ Page.Trainer = class extends Page {
 
 				let trainer = data.team.getTrainer(+row.cells['#'].textContent); 
 
-				trainer.salary = +row.cells['Gehalt'].textContent.replace(/\./g, "");
+				trainer.salary = +row.cells['Gehalt'].textContent.replaceAll('.', '');
 				trainer.contractTerm = +row.cells['Vertrag'].textContent;
 
 				trainer.legacySkill = Team.Trainer.LIST[row.cells['Skill'].textContent].legacySkill;

--- a/extension/source/pages/youth.options.js
+++ b/extension/source/pages/youth.options.js
@@ -14,7 +14,7 @@ Page.YouthOptions = class extends Page {
 
 		data.viewSettings.youthSupportPerDay = +doc.getElementsByName("foerderung")[0].value;	
 
-		let matches = /Du hast die Jugendschranke derzeit gesetzt. Dein Jahrgang (\d+) und\s(.+)\swerden nur minimal gef.+rdert/gm.exec(doc.body.textContent);
+		let matches = /Du hast die Jugendschranke derzeit gesetzt. Dein Jahrgang (\d+) und\s(.+)\swerden nur minimal gef.rdert/gm.exec(doc.body.textContent);
 		
 		if (matches) {
 			data.viewSettings.youthSupportBarrierSeason = +matches[1];


### PR DESCRIPTION
- Substituted pattern replace(/\./g, '') with character elimination
replaceAll('.', '')
- Used '.' instead of '.+' in patterns for matching umlauts
- main.js: extract(): Correctly matched leagues with postscript A to D

fixes #16