### PR TITLE
Bugfix duplicated bans

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ For testing the extension `Karma Test Explorer for Angular, Jasmine, and Mocha` 
 </pre>
 The coverage reports are created with `npm test` in the folder `.coverage`. Based on the `summary.json` the coverage badge is updated in the README with `npm run badge`.
 
-The release arichve (zip) can be created by running `gulp` in the folder `release`.
+The release archive (zip) can be created by running `gulp` in the folder `release`.

--- a/extension/source/pages/showteam.overview.js
+++ b/extension/source/pages/showteam.overview.js
@@ -179,6 +179,7 @@ Page.ShowteamOverview = class extends Page.Showteam {
 						let banAbbr = HtmlUtil.createAbbreviation(
 							`${ban.duration.toString()} ${ban.duration === 1 ? ban.type.description : ban.type.descriptionPlural}`,
 							`${ban.duration.toString()}${ban.type.abbr}`);
+						row.cells['Sperre'].textContent = '';
 						row.cells['Sperre'].appendChild(banAbbr);
 					});
 				}

--- a/test/pages/leaguetable.spec.js
+++ b/test/pages/leaguetable.spec.js
@@ -28,9 +28,9 @@ describe('Page.LeagueTable', () => {
 	it('should extract league table and current ranking with team performance', (done) => {
 
 		Fixture.getDocument('lt_performance.php', doc => {
-			
+
 			page.extract(doc, data);
-			
+
 			expect(data.team.league.size).toEqual(10);
 			expect(data.viewSettings.leagueRanking).toEqual(2);
 
@@ -43,11 +43,11 @@ describe('Page.LeagueTable', () => {
 	it('should not extract if not current teams league', (done) => {
 
 		Fixture.getDocument('lt.php', doc => {
-			
+
 			data.team.id = 4711;
 
 			page.extract(doc, data);
-			
+
 			expect(data.team.league.size).toBeUndefined();
 			expect(data.viewSettings.leagueRanking).toEqual(1);
 


### PR DESCRIPTION
Clear cell before adding content, such that the player's ban string appears just once

fixes #20