### PR TITLE
Unscript showteam season

### DIFF
--- a/extension/source/page.js
+++ b/extension/source/page.js
@@ -173,6 +173,14 @@ class Page {
 			doc.body.appendChild(marker);
 		}
 	}
+
+	/**
+	 * Reverts Greasemonkey script modifications on the given document.
+	 *
+	 * @param {Document} doc the document
+	 */
+	unscript (doc = document) {}
+
 	/**
 	 * The extract method used when processing the page.
 	 *
@@ -214,6 +222,9 @@ class Page {
 		let page = this;
 		if (page.reloadIfAlreadyExtended(doc)) return;
 		page.check(doc);
+		if (doc.getElementById('options')) {	// Greasemonkey script invoked!
+			page.unscript(doc);
+		}
 		Persistence.updateExtensionData(data => {
 			if (!data.nextZat && !page.equals(new Page.Main())) {
 				data.pagesToRequest = [];

--- a/extension/source/pages/main.js
+++ b/extension/source/pages/main.js
@@ -17,6 +17,10 @@ Page.Main = class extends Page {
 
 		super.check(doc);
 
+		if (doc.getElementById('options')) {
+			super.unscript(doc);
+		}
+
 		let teamChangeLink = doc.querySelector('a[href="?changetosecond=true"]');
 		let matches = /Willkommen im Managerb.ro von (.+)/gm.exec(teamChangeLink.parentElement.childNodes[0].textContent);
 

--- a/extension/source/pages/showteam.season.js
+++ b/extension/source/pages/showteam.season.js
@@ -19,6 +19,31 @@ Page.ShowteamSeason = class extends Page {
 
 	static GAMEINFO_NOT_SET = ['Blind Friendly gesucht!', 'reserviert', 'spielfrei'];
 
+	static UNALIASGAMETYPE = {
+		"^$"	:	'spielfrei',
+		'FSS'	:	'Friendly',
+		'Pokal'	:	'LP',
+		'Super'	:	'Supercup',
+		'(H)'	:	': Heim',
+		'(A)'	:	': Ausw\u00E4rts'
+	};
+
+	/**
+	 * @param {Document} doc
+	 */
+	unscript (doc) {
+
+		// Undo option 'shortKom' from OS2.spielplan.user.js:
+		HtmlUtil.getTableRowsByHeader(doc, ...Page.ShowteamSeason.HEADERS).forEach(row => {
+			let gameInfo = row.cells['Spielart'].textContent;
+			let gameInfoOrg = Object.entries(Page.ShowteamSeason.UNALIASGAMETYPE).reduce(
+					(gameType, [key, value]) => gameType.replace(key, value), gameInfo);
+			if (gameInfoOrg !== gameInfo) {
+				row.cells['Spielart'].textContent = gameInfoOrg;
+			}
+		});
+	}
+
 	/**
 	 * @param {Document} doc
 	 * @param {ExtensionData} data

--- a/extension/source/pages/showteam.season.js
+++ b/extension/source/pages/showteam.season.js
@@ -20,7 +20,7 @@ Page.ShowteamSeason = class extends Page {
 	static GAMEINFO_NOT_SET = ['Blind Friendly gesucht!', 'reserviert', 'spielfrei'];
 
 	static UNALIASGAMETYPE = {
-		"^$"	:	'spielfrei',
+		'^$'	:	'spielfrei',
 		'FSS'	:	'Friendly',
 		'Pokal'	:	'LP',
 		'Super'	:	'Supercup',

--- a/extension/source/pages/showteam.season.js
+++ b/extension/source/pages/showteam.season.js
@@ -19,7 +19,7 @@ Page.ShowteamSeason = class extends Page {
 
 	static GAMEINFO_NOT_SET = ['Blind Friendly gesucht!', 'reserviert', 'spielfrei'];
 
-	static UNALIASGAMETYPE = {
+	static UNALIAS_GAMETYPE = {
 		'^$'	:	'spielfrei',
 		'FSS'	:	'Friendly',
 		'Pokal'	:	'LP',
@@ -36,7 +36,7 @@ Page.ShowteamSeason = class extends Page {
 		// Undo option 'shortKom' from OS2.spielplan.user.js:
 		HtmlUtil.getTableRowsByHeader(doc, ...Page.ShowteamSeason.HEADERS).forEach(row => {
 			let gameInfo = row.cells['Spielart'].textContent;
-			let gameInfoOrg = Object.entries(Page.ShowteamSeason.UNALIASGAMETYPE).reduce(
+			let gameInfoOrg = Object.entries(Page.ShowteamSeason.UNALIAS_GAMETYPE).reduce(
 					(gameType, [key, value]) => gameType.replace(key, value), gameInfo);
 			if (gameInfoOrg !== gameInfo) {
 				row.cells['Spielart'].textContent = gameInfoOrg;


### PR DESCRIPTION
[add unscript() framework](https://github.com/rombau/osext2/commit/ffee782787b0beaf4b905567333b6385d8b4fb83)
Page.unscript(doc) reverts Greasemonkey modifications on doc

[add Page.ShowteamSeason.unscript() for OS2.spielplan.user.js](https://github.com/rombau/osext2/commit/cafe3a35bf9f6cf996023e41ea8888338d3612a3)
reverts shortened game types (option 'shortKom')

refs https://github.com/rombau/osext2/issues/9